### PR TITLE
Set priorityClass for Kube Proxy

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,3 +6,8 @@ kubernetes_service_addresses: "172.21.0.0/16"
 kubernetes_version: "1.4.1"
 hyperkube: "gcr.io/google_containers/hyperkube:v{{kubernetes_version}}"
 kube_apiserver_secure_port: 6443
+
+kube_proxy_requests_cpu: "200m"
+kube_proxy_requests_memory: "128Mi"
+kube_proxy_limits_cpu: "200m" # requests and limits should be same to get Guaranteed QoS
+kube_proxy_limits_memory: "128Mi"

--- a/templates/kube-proxy.yaml
+++ b/templates/kube-proxy.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: kube-system
 spec:
   hostNetwork: true
+  priorityClassName: system-node-critical
   containers:
   - name: kube-proxy
     image: "{{hyperkube}}"
@@ -13,6 +14,13 @@ spec:
     - proxy
     - --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml
     - --proxy-mode=iptables
+    resources:
+      requests:
+        cpu: {{kube_proxy_requests_cpu}}
+        memory: {{kube_proxy_requests_memory}}
+      limits:
+        cpu: {{kube_proxy_limits_cpu}}
+        memory: {{kube_proxy_limits_memory}}
     securityContext:
       privileged: true
     volumeMounts:


### PR DESCRIPTION
Also, set equal CPU and Memory requests and limits so that Kube Proxy will get Guaranteed QoS. This is required per https://v1-9.docs.kubernetes.io/docs/tasks/administer-cluster/out-of-resource/ ("If necessary, kubelet evicts Pods one at a time to reclaim disk when DiskPressure is encountered. If the kubelet is responding to inode starvation, it reclaims inodes by evicting Pods with the lowest quality of service first. If the kubelet is responding to lack of available disk, it ranks Pods within a quality of service that consumes the largest amount of disk and kill those first.")