### PR TITLE
Add ability to increase log level for kube-proxy

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,3 +11,4 @@ kube_proxy_requests_cpu: "200m"
 kube_proxy_requests_memory: "128Mi"
 kube_proxy_limits_cpu: "200m" # requests and limits should be same to get Guaranteed QoS
 kube_proxy_limits_memory: "128Mi"
+kube_proxy_worker_log_level: 0

--- a/templates/kube-proxy.yaml
+++ b/templates/kube-proxy.yaml
@@ -12,6 +12,7 @@ spec:
     command:
     - /hyperkube
     - proxy
+    - -v={{kube_proxy_worker_log_level}}
     - --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml
     - --proxy-mode=iptables
     resources:


### PR DESCRIPTION
Passing -v option to kube-proxy to be able to set log-level for kube-proxy on workers.