### PR TITLE
Upgrade Kubelet to version 1.14.3 and some minor fixes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@ kube_config_dir: "/etc/kubernetes"
 kube_cert_dir: "/etc/kubernetes/ssl"
 kube_manifests_dir: "/etc/kubernetes/manifests"
 kubernetes_service_addresses: "172.21.0.0/16"
-kubernetes_version: "1.4.1"
+kubernetes_version: "1.14.3"
 hyperkube: "gcr.io/google_containers/hyperkube:v{{kubernetes_version}}"
 kube_apiserver_secure_port: 6443
 


### PR DESCRIPTION
Upgrade Kubelet to version 1.14.3. Also fix the variables names to be more consistent across repos.
Release notes for Kubernetes 1.14.3 available at https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.14.md#v1143