### PR TITLE
Run 'systemctl reset-failed kubelet' prior to restarting kubelet.

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -10,6 +10,12 @@
 - name: restart daemons
   command: /bin/true
   notify:
+    - reset failed kubelet
+
+- name: reset failed kubelet
+  become: true
+  command: systemctl reset-failed kubelet
+  notify:
     - restart kubelet
 
 - name: restart kubelet

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -62,9 +62,11 @@
 - name: install kubeconfig
   become: yes
   template: src=worker-kubeconfig.yaml dest={{kube_config_dir}}/worker-kubeconfig.yaml
-  notify: restart kubelet
+  notify:
+    - reset failed kubelet
 
 - name: install proxy pod
   become: yes
   template: src=kube-proxy.yaml dest={{kube_manifests_dir}}/kube-proxy.yaml
-  notify: restart kubelet
+  notify:
+    - reset failed kubelet


### PR DESCRIPTION
Run 'systemctl reset-failed kubelet' prior to restarting kubelet.
This is needed to make sure that kubelet is not blocked from restarting by systemd start rate limiting configured with StartLimitIntervalSec= and StartLimitBurst=.