### PR TITLE
If kubernetes_enable_cni=True, start kube-proxy with --cluster-cidr option to support CNI Plugins (e.g. Antrea)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,8 @@ kube_config_dir: "/etc/kubernetes"
 kube_cert_dir: "/etc/kubernetes/ssl"
 kube_manifests_dir: "/etc/kubernetes/manifests"
 kubernetes_service_addresses: "172.21.0.0/16"
+kubernetes_cluster_cidr: "172.34.0.0/16"
+kubernetes_enable_cni: False
 kubernetes_version: "1.14.3"
 hyperkube: "gcr.io/google_containers/hyperkube:v{{kubernetes_version}}"
 kube_apiserver_secure_port: 6443

--- a/templates/kube-proxy.yaml
+++ b/templates/kube-proxy.yaml
@@ -22,6 +22,9 @@ spec:
     - --metrics-port=10249
     - --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml
     - --proxy-mode=iptables
+{% if kubernetes_enable_cni %}
+    - --cluster-cidr={{kubernetes_cluster_cidr}}
+{% endif %}
     resources:
       requests:
         cpu: {{kube_proxy_requests_cpu}}


### PR DESCRIPTION
If kubernetes_enable_cni=True, start kube-proxy with --cluster-cidr option to support CNI Plugins (e.g. Antrea)